### PR TITLE
MCKIN-9153 Report cmi.progress_measure to completion API if emitted

### DIFF
--- a/scormxblock/scormxblock.py
+++ b/scormxblock/scormxblock.py
@@ -516,7 +516,7 @@ class ScormXBlock(XBlock):
         :return: progress_measure if found, else 0
         """
         progress_sum = 0
-        scos = scorm_data.get('scos', [])
+        scos = scorm_data.get('scos', {})
         for sco in scos.values():
             sco_data = sco.get('data', {})
             try:

--- a/scormxblock/scormxblock.py
+++ b/scormxblock/scormxblock.py
@@ -498,7 +498,7 @@ class ScormXBlock(XBlock):
         Update progress % if cmi.progress_measure is emitted
         Else check status and mark 100% completion if course is complete
         """
-        progress_measure = self.calc_progress_measure(scorm_data)
+        progress_measure = self.calculate_progress_measure(scorm_data)
         if progress_measure > 0:
             self._publish_progress(progress_measure)
         elif scorm_data.get('status', '') in constants.SCORM_COMPLETION_STATUS:
@@ -510,7 +510,7 @@ class ScormXBlock(XBlock):
         """
         self.runtime.publish(self, 'completion', {'completion': completion})
 
-    def calc_progress_measure(self, scorm_data):
+    def calculate_progress_measure(self, scorm_data):
         """
         Returns the averaged progress_measure of all scos in the current scorm content
         :return: progress_measure if found, else 0
@@ -520,16 +520,12 @@ class ScormXBlock(XBlock):
         for sco in scos.values():
             sco_data = sco.get('data', {})
             try:
-                progress_sum = progress_sum + float(sco_data.get('cmi.progress_measure', '0.0'))
+                progress_sum += float(sco_data.get('cmi.progress_measure', '0.0'))
             except (ValueError, AttributeError):
                 pass
-        try:
-            progress_measure = progress_sum / len(scos)
-        except ZeroDivisionError:
-            progress_measure = 0
-        finally:
-            return progress_measure
 
+        return progress_sum / len(scos) if len(scos) else 0
+        
     @staticmethod
     def workbench_scenarios():
         """A canned scenario for display in the workbench."""

--- a/scormxblock/scormxblock.py
+++ b/scormxblock/scormxblock.py
@@ -499,7 +499,7 @@ class ScormXBlock(XBlock):
         Else check status and mark 100% completion if course is complete
         """
         progress_measure = self.calculate_progress_measure(scorm_data)
-        if progress_measure > 0:
+        if progress_measure:
             self._publish_progress(progress_measure)
         elif scorm_data.get('status', '') in constants.SCORM_COMPLETION_STATUS:
             self._publish_progress(1.0)
@@ -525,7 +525,7 @@ class ScormXBlock(XBlock):
                 pass
 
         return progress_sum / len(scos) if len(scos) else 0
-        
+
     @staticmethod
     def workbench_scenarios():
         """A canned scenario for display in the workbench."""

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ def package_data(pkg, roots):
 
 setup(
     name='scormxblock-xblock',
-    version='2.0.13',
+    version='2.0.14',
     description='XBlock to integrate SCORM content packages',
     packages=[
         'scormxblock',


### PR DESCRIPTION
If the cmi.progress_measure is present in scorm_data, it is reported to the completion API

A scorm course emitting the required metric has been attached to test the functionality (if required).

**Scenerio:**
A user covers x% of the course in the scormxblock with a course that emits cmi.progress_measure in set/get calls.

**Before:**
x% completion is not updated in the progress 

**After:**
x% completion is updated in the progress 

Steps to reproduce:

On studio, Create a new module with a Scorm Xblock. Import the given course in the scorm xblock (optional: and select popup within the 'edit menu'.)
On Master:
1.1 Open the module you just created and launch the scorm content from within the xblock.
1.2 Within the scorm content, click 'Next' 1-3 times.
1.3 Exit the popup (if you are viewing the content on a popup).
1.4 Return to the module page from where you initially launched the scorm content in step 1.1.
1.5 Click on the course name in the top bar to redirect to the course landing page.
1.6 Note that the progress **percentage** has not been updated in the progress section on the course landing page and lesson tile. (The course may be marked as compelte which is undesirable)
On branch:
1.1 - 1.5 Same as master.
1.6 Note that the progress **percentage** has been updated in the progress section on the course landing page and lesson tile. 

_Attached course:_
[RunTimeAdvancedCalls_SCORM20043rdEdition.zip](https://github.com/mckinseyacademy/xblock-scorm/files/2745279/RunTimeAdvancedCalls_SCORM20043rdEdition.zip)