### PR TITLE
MCKIN-9231 Report 1% progress first time user launches course

### DIFF
--- a/scormxblock/scormxblock.py
+++ b/scormxblock/scormxblock.py
@@ -391,7 +391,9 @@ class ScormXBlock(XBlock):
         """
         # TODO: handle errors
         # TODO: this is specific to SSLA player at this point.  evaluate for broader use case
-        return Response(self.raw_scorm_status, content_type='application/json', charset='UTF-8')
+        response = Response(self.raw_scorm_status, content_type='application/json', charset='UTF-8')
+        self.mark_in_progress(response.body)
+        return response
 
     @XBlock.handler
     def set_raw_scorm_status(self, request, suffix=''):
@@ -503,6 +505,15 @@ class ScormXBlock(XBlock):
             self._publish_progress(progress_measure)
         elif scorm_data.get('status', '') in constants.SCORM_COMPLETION_STATUS:
             self._publish_progress(1.0)
+
+    def mark_in_progress(self, scorm_response_body):
+        """
+        Mark 1% progress upon launching the scorm content for the first time
+        This also marks the module as 'in-progress'
+        Scorm response is empty when user launches course first time
+        """
+        if scorm_response_body == '{}':
+            self._publish_progress(0.01)
 
     def _publish_progress(self, completion):
         """


### PR DESCRIPTION
https://edx-wiki.atlassian.net/browse/MCKIN-9231

Scenerio:
A user clicks the launch module button in the scormxblock to launch the content.

Before:
The xblock (or the module containing that xblock) is not marked as in progress.

After:
The xblock (or the module containing that xblock) is marked as in progress.

Steps to reproduce:

On studio, Create a new module with a Scorm Xblock. Import the given course in the scorm xblock (optional: and select popup within the 'edit menu'.)
On Master:
1.1 Open the module you just created and launch the scorm content from within the xblock.
1.2 When the content is properly launched, close the popup (if opened in popup). If iframe, skip to step 1.3
1.3 Return to the module page from where you initially launched the scorm content in step 1.1.
1.4 Click on the course name in the top bar to redirect to the course landing page.
1.5 Note that the lesson tile has not been marked as inprogress.
On branch:
1.1 - 1.5 Same as master.
1.6 Note that the lesson tile has been marked as inprogress.

Attached course:
[computing-and-design-no-quiz-scorm2004_4-frRPdyUm.zip](https://github.com/mckinseyacademy/xblock-scorm/files/2759457/computing-and-design-no-quiz-scorm2004_4-frRPdyUm.zip)
