### PR TITLE
MCKIN9201,MCKIN8878,MCKIN9150 Added two new radio options manual and auto for popup

### DIFF
--- a/scormxblock/static/html/scormxblock.html
+++ b/scormxblock/static/html/scormxblock.html
@@ -13,14 +13,16 @@ for item in list({player_config}.items()):
 <div class="scormxblock_block">
     <h3 class="scorm_name">{self.display_name} <span class="scorm_weight"></span></h3>
     <div class="scorm_description">{self.description}
-        <div class="scorm_launch"><button id="scorm-launch-{self.url_name}">Launch module</button></div>
+        % if {show_popup_manually}:
+            <div class="scorm_launch"><button id="scorm-launch-{self.url_name}">{self.launch_button_text}</button></div>
+        % endif
     </div>
 
 </div>
 
-<iframe class="scormxblock_hostframe" id="scormxblock-{self.url_name}" src="" data-block_id="{self.url_name}"  
+<iframe class="scormxblock_hostframe" id="scormxblock-{self.url_name}" src="" data-block_id="{self.url_name}"
 data-player_url="{scorm_player_url}" data-display_type="{self.display_type}" data-display_width="{self.display_width}"
-data-display_height="{self.display_height}"
+data-display_height="{self.display_height}" data-popup_launch_type="{self.popup_launch_type}"
 data-get_url="{get_url}" data-set_url="{set_url}"
 data-course_location="{scorm_file}/" data-course_id="{self.course_id}"
 data-student_name="{self.student_name}" data-student_id="{self.student_id}"

--- a/scormxblock/static/html/studio.html
+++ b/scormxblock/static/html/studio.html
@@ -69,6 +69,24 @@
         <div class="setting-help" style="display:block">${block.fields['display_type'].help}</div>        
       </div>
     </li>
+    <li class="field comp-setting-entry is-set" id="popup_type">
+      <div class="wrapper-comp-setting">
+        <fieldset>
+          <legend class="label setting-label">Popup Launch Type</legend>
+          %for opt in block.fields['popup_launch_type'].values:
+            <label class="label" for="popup_launch_type_${opt}">${opt}</label> <input class="input setting-input" name="popup_launch_type" id="popup_launch_type_${opt}" ${block.popup_launch_type==opt and 'checked '} type="radio" value="${opt}" style="width:auto;height:auto" />
+          %endfor
+        </fieldset>
+        <div class="setting-help" style="display:block">${block.fields['popup_launch_type'].help}</div>
+      </div>
+    </li>
+    <li class="field comp-setting-entry is-set" id="launch_button">
+      <div class="wrapper-comp-setting">
+        <label class="label setting-label" for="launch_button_text">Launch Button Text</label>
+        <input class="input setting-input" maxlength="20" name="launch_button_text" id="launch_button_text" value="${block.launch_button_text}" type="text" />
+        <div class="setting-help" style="display:block">${block.fields['launch_button_text'].help}</div>
+      </div>
+    </li>
     <li class="field comp-setting-entry is-set">
       <div class="wrapper-comp-setting">
         <label class="label setting-label" for="display_width">Display Width</label>

--- a/scormxblock/static/js/src/scormxblock.js
+++ b/scormxblock/static/js/src/scormxblock.js
@@ -81,24 +81,33 @@ function ScormXBlock_${block_id}(runtime, element) {
 
     //post message with data to player frame
     //player must be in an iframe and not a popup due to limitations in Internet Explorer's postMessage implementation
-    launch_btn_${block_id} = $('#scorm-launch-${block_id}');
     host_frame_${block_id} = $('#scormxblock-${block_id}');
     host_frame_${block_id}.data('csrftoken', $.cookie('csrftoken'));
-    launch_btn_${block_id}.on('click', function() {
-      playerWin = null;
-      if (host_frame_${block_id}.data('display_type') == 'iframe') {
-        host_frame_${block_id}.css('height', host_frame_${block_id}.data('display_height') + 'px');
-      }
-      host_frame_${block_id}.attr('src',host_frame_${block_id}.data('player_url'));
-      $(host_frame_${block_id}).on('load', function() {
-        playerWin = host_frame_${block_id}[0].contentWindow;
-        playerWin.postMessage(host_frame_${block_id}.data(), '*');
-         launch_btn_${block_id}.attr('disabled','true');
-      });
+    if (host_frame_${block_id}.data('display_type') == 'iframe') {
+      host_frame_${block_id}.css('height', host_frame_${block_id}.data('display_height') + 'px');
+      showScormContent(host_frame_${block_id})
+    }
+    else if ((host_frame_${block_id}.data('display_type') == 'popup') && (host_frame_${block_id}.data('popup_launch_type') == 'auto')){
+      showScormContent(host_frame_${block_id})
+    }
+    else{
+      launch_btn_${block_id} = $('#scorm-launch-${block_id}');
+      launch_btn_${block_id}.on('click', function() {
+        showScormContent(host_frame_${block_id})
+        launch_btn_${block_id}.attr('disabled','true')
+        });
       $(host_frame_${block_id}).on('unload', function() {
         launch_btn_${block_id}.removeAttr('disabled');
       })
-    });    
-
+    }
   });
+
+  function showScormContent(host_frame) {
+    playerWin = null;
+    host_frame.attr('src',host_frame.data('player_url'));
+    $(host_frame).on('load', function() {
+      playerWin = host_frame[0].contentWindow;
+      playerWin.postMessage(host_frame.data(), '*');
+    });
+}
 }

--- a/scormxblock/static/js/src/studio.js
+++ b/scormxblock/static/js/src/studio.js
@@ -83,9 +83,14 @@ function ScormStudioXBlock(runtime, element) {
     var display_width = $(element).find('input[name=display_width]').val();
     var display_height = $(element).find('input[name=display_height]').val();
     var display_type = $(element).find('input[name=display_type]:checked').val();
+    var popup_launch_type = $(element).find('input[name=popup_launch_type]:checked').val();
+    var launch_button_text = $(element).find('input[name=launch_button_text]').val();
     var scorm_player = $(element).find('select[name=scorm_player]').val();
     var encoding = $(element).find('select[name=encoding]').val();
     var player_configuration = $(element).find('textarea[name=player_configuration]').val();
+    if (!launch_button_text){
+      launch_button_text = 'Launch'
+    }
     form_data.append('file', file_data);
     form_data.append('display_name', display_name);
     form_data.append('description', description);
@@ -93,6 +98,8 @@ function ScormStudioXBlock(runtime, element) {
     form_data.append('display_height', display_height);
     form_data.append('weight', weight);
     form_data.append('display_type', display_type);
+    form_data.append('popup_launch_type', popup_launch_type);
+    form_data.append('launch_button_text', launch_button_text);
     form_data.append('scorm_player', scorm_player);
     form_data.append('encoding', encoding);
     form_data.append('player_configuration', player_configuration);
@@ -117,4 +124,41 @@ function ScormStudioXBlock(runtime, element) {
     runtime.notify('cancel', {});
   });
 
+  $(element).find('input[name=display_type]').bind('click', function() {
+    showPopupLaunchType()
+  });
+
+  $(element).find('input[name=popup_launch_type]').bind('click', function() {
+    var display_type_popup = true;
+    showLaunchButtonTextField(display_type_popup)
+
+  });
+
+  function showPopupLaunchType() {
+      var display_type = $(element).find('input[name=display_type]:checked').val();
+      var display_type_popup = false;
+      if(display_type === 'popup'){
+        $(element).find('#popup_type').show();
+        display_type_popup = true;
+        showLaunchButtonTextField(display_type_popup)
+      }
+      else{
+        $(element).find('#popup_type').hide();
+        showLaunchButtonTextField(display_type_popup)
+      }
+  }
+
+  function showLaunchButtonTextField(display_type_popup) {
+        var popup_launch_type = $(element).find('input[name=popup_launch_type]:checked').val();
+        if(display_type_popup === true && popup_launch_type === 'manual'){
+          $(element).find('#launch_button').show();
+        }
+        else{
+          $(element).find('#launch_button').hide();
+        }
+  }
+
+  $(function ($) {
+      showPopupLaunchType();
+    })
 }

--- a/scormxblock/static/js/src/studio.js
+++ b/scormxblock/static/js/src/studio.js
@@ -124,31 +124,37 @@ function ScormStudioXBlock(runtime, element) {
     runtime.notify('cancel', {});
   });
 
+  //when Display Type is changed trigger the showHidePopupLaunchOptions function.
   $(element).find('input[name=display_type]').bind('click', function() {
-    showPopupLaunchType()
+    showHidePopupLaunchOptions()
   });
 
+  //when Popup Launch Type is changed trigger the showHideLaunchButtonTextField function.
   $(element).find('input[name=popup_launch_type]').bind('click', function() {
     var display_type_popup = true;
-    showLaunchButtonTextField(display_type_popup)
+    showHideLaunchButtonTextField(display_type_popup)
 
   });
 
-  function showPopupLaunchType() {
+  //when Display Type is popup show popup types and when it is iframe hide popup types
+  //also trigger the showHideLaunchButtonTextField function.
+  function showHidePopupLaunchOptions() {
       var display_type = $(element).find('input[name=display_type]:checked').val();
       var display_type_popup = false;
       if(display_type === 'popup'){
         $(element).find('#popup_type').show();
         display_type_popup = true;
-        showLaunchButtonTextField(display_type_popup)
+        showHideLaunchButtonTextField(display_type_popup)
       }
       else{
         $(element).find('#popup_type').hide();
-        showLaunchButtonTextField(display_type_popup)
+        showHideLaunchButtonTextField(display_type_popup)
       }
   }
 
-  function showLaunchButtonTextField(display_type_popup) {
+  //when display type is popup and popup type is manual show launch button text field,
+  //in other cases hide show launch button text field
+  function showHideLaunchButtonTextField(display_type_popup) {
         var popup_launch_type = $(element).find('input[name=popup_launch_type]:checked').val();
         if(display_type_popup === true && popup_launch_type === 'manual'){
           $(element).find('#launch_button').show();
@@ -159,6 +165,6 @@ function ScormStudioXBlock(runtime, element) {
   }
 
   $(function ($) {
-      showPopupLaunchType();
+      showHidePopupLaunchOptions();
     })
 }

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ def package_data(pkg, roots):
 
 setup(
     name='scormxblock-xblock',
-    version='2.0.14',
+    version='2.0.15',
     description='XBlock to integrate SCORM content packages',
     packages=[
         'scormxblock',


### PR DESCRIPTION
https://edx-wiki.atlassian.net/browse/MCKIN-9201
https://edx-wiki.atlassian.net/browse/MCKIN-8878
https://edx-wiki.atlassian.net/browse/MCKIN-9150

Scenario Studio Side:
When the user clicks on popup radio button then he should be able to see two other radio buttons with titles
Manual
Auto
when the user clicks on Manual then another field should appear where the user can enter text.


Before:
When the user clicks on the popup radio button then no other fields appear.

Steps to Verify:
**Case 1:**
On studio, Create a new module with a Scorm Xblock. Import the given course in the scorm xblock (Select Iframe from the menu)
On Master:
1.1 Open the module you just created in Apros and you will see Launch button on page and when you click on the button, content will load in Iframe.
On Branch:
1.1 Open the module you just created in Apros and there will be no Launch button and Iframe will start loading automatically.

**Case 2:**
On studio, Create a new module with a Scorm Xblock. Import the given course in the scorm xblock (Select popup from menu)
On Master:
When you click on popup then no other options will appear.
1.1 Open the module you just created in Apros and you will see Launch button on page and when you click on the button, content will load in popup.
On Branch:
When you click on popup then two more options will appear. Click on the Auto option
1.1 Open the module you just created in Apros and there will be no Launch button and Popup will start loading automatically.

**Case 3:**
On studio, Create a new module with a Scorm Xblock. Import the given course in the scorm xblock (Select popup from menu)
On Master:
When you click on popup then no other options will appear.
1.1 Open the module you just created in Apros and you will see Launch button on page and when you click on the button, content will load in popup.
On Branch:
When you click on popup then two more options will appear. Click on Manual option. Another filed for launch button text will appear. Add some text in this field
1.1 Open the module you just created in Apros and there will be a Launch button with the custom text you entered on the studio side. When you click on the button popup will appear and content start loading.

If no text will be entered then text will be Launch. Also the max length for Launch button should be 20.

Attached course:
[computing-and-design-no-quiz-scorm2004_4-frRPdyUm.zip](https://github.com/mckinseyacademy/xblock-scorm/files/2759457/computing-and-design-no-quiz-scorm2004_4-frRPdyUm.zip)
