### PR TITLE
MCKIN-9408 Progress is updated only if larger than previous progress

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ def package_data(pkg, roots):
 
 setup(
     name='scormxblock-xblock',
-    version='2.0.15',
+    version='2.0.16',
     description='XBlock to integrate SCORM content packages',
     packages=[
         'scormxblock',


### PR DESCRIPTION
https://edx-wiki.atlassian.net/browse/MCKIN-9408

Progress should be reported to the completion api only if the current value is larger than the previously stored value.

**Steps to check:**
_This branch:_
1. Create a module with scormxblock having attached course(preferrably iframe).
2. Click next 2-3 times.
3. See progress on the lesson tile on the course landing page in new tab.
4. Refresh the module page containing the scormxblock.
5. Click 'Cancel' on the alert to reset the progress.
6. Click next 1-2 times.
7. Refresh course landing page (opened previously in new tab) to see that progress has not been reduced from previous value.
8. Return to module page tab and click next 4-5 times more.
Repeat step 7 to find progress is now updated to a greater value.

_Master branch:_
In step 7 above, the progress is updated to a lower value on the lesson tile on the course landing page.

Course to test on:
[RunTimeAdvancedCalls_SCORM20043rdEdition.zip](https://github.com/mckinseyacademy/xblock-scorm/files/2836789/RunTimeAdvancedCalls_SCORM20043rdEdition.zip)
