### PR TITLE
MCKIN-9492 Hide description if empty

### DIFF
--- a/scormxblock/static/html/scormxblock.html
+++ b/scormxblock/static/html/scormxblock.html
@@ -1,3 +1,4 @@
+## Mako template library is being used here for loops and if's
 <%!
 import cgi
 %>
@@ -10,14 +11,19 @@ for item in list({player_config}.items()):
     player_config_attrs += 'data-{{}}="{{}}" '.format(item[0], cgi.escape(item[1], quote=True))
 %>
 
+<%
+should_show_description = ('{self.description}' != '') or ({show_popup_manually})
+%>
+
 <div class="scormxblock_block">
     <h3 class="scorm_name">{self.display_name} <span class="scorm_weight"></span></h3>
-    <div class="scorm_description">{self.description}
-        % if {show_popup_manually}:
-            <div class="scorm_launch"><button id="scorm-launch-{self.url_name}">{self.launch_button_text}</button></div>
-        % endif
-    </div>
-
+    % if should_show_description:
+        <div class="scorm_description">{self.description}
+            % if {show_popup_manually}:
+                <div class="scorm_launch"><button id="scorm-launch-{self.url_name}">{self.launch_button_text}</button></div>
+            % endif
+        </div>
+    % endif
 </div>
 
 <iframe class="scormxblock_hostframe" id="scormxblock-{self.url_name}" src="" data-block_id="{self.url_name}"

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ def package_data(pkg, roots):
 
 setup(
     name='scormxblock-xblock',
-    version='2.0.17',
+    version='2.0.18',
     description='XBlock to integrate SCORM content packages',
     packages=[
         'scormxblock',


### PR DESCRIPTION
Add condition in html file to hide the description div if description contains empty string.

Steps to reproduce:
_Master branch:_
1. Create a module with scorm xblock set as auto-popup (So Launch button doesnot show)
2. Make sure description is empty in studio
3. Open module on apros.
4. You will see an undesired grey section on the top of the xblock.
![image 29](https://user-images.githubusercontent.com/17109504/53076555-b7731700-3511-11e9-8a5a-237f13fd02c2.png)

_This branch:_
..Steps 1-3 from master branch
4. You will not see the undesired grey section on top of xblock. 