### PR TITLE
MCKIN-9933 Revert 1% progress feature

### DIFF
--- a/scormxblock/scormxblock.py
+++ b/scormxblock/scormxblock.py
@@ -424,9 +424,7 @@ class ScormXBlock(XBlock):
         """
         # TODO: handle errors
         # TODO: this is specific to SSLA player at this point.  evaluate for broader use case
-        response = Response(self.raw_scorm_status, content_type='application/json', charset='UTF-8')
-        self.mark_in_progress(response.body)
-        return response
+        return Response(self.raw_scorm_status, content_type='application/json', charset='UTF-8')
 
     @XBlock.handler
     def set_raw_scorm_status(self, request, suffix=''):
@@ -587,15 +585,6 @@ class ScormXBlock(XBlock):
                 self._publish_progress(progress_measure)
         elif current_scorm_data.get('status', '') in constants.SCORM_COMPLETION_STATUS:
             self._publish_progress(1.0)
-
-    def mark_in_progress(self, scorm_response_body):
-        """
-        Mark 1% progress upon launching the scorm content for the first time
-        This also marks the module as 'in-progress'
-        Scorm response is empty when user launches course first time
-        """
-        if scorm_response_body == '{}':
-            self._publish_progress(0.01)
 
     def _publish_progress(self, completion):
         """

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ def package_data(pkg, roots):
 
 setup(
     name='scormxblock-xblock',
-    version='2.0.18',
+    version='2.0.19',
     description='XBlock to integrate SCORM content packages',
     packages=[
         'scormxblock',


### PR DESCRIPTION
Ticket: https://edx-wiki.atlassian.net/browse/MCKIN-9933

This PR reverts the feature where scorm xblock was marked as in-progress(1% progress) upon launching.

Steps to reproduce:
1. Launch a scorm xblock (preferrably with a Rise course).
2. Open the course landing page.
3. 1% progress is not updated for the lesson tile launched earlier.