### PR TITLE
MCKIN-9654 Handle manual popup close

### DIFF
--- a/scormxblock/static/html/scormxblock.html
+++ b/scormxblock/static/html/scormxblock.html
@@ -16,9 +16,7 @@ for item in list({player_config}.items()):
     % if '{self.description}' != '':
         <div class="scorm_description">{self.description}</div>
     % endif
-    % if {show_popup_manually}:
-        <div class="scorm_launch"><button id="scorm-launch-{self.url_name}">{self.launch_button_text}</button></div>
-    % endif
+    <div class="scorm_launch"><button id="scorm-launch-{self.url_name}">{self.launch_button_text}</button></div>
 </div>
 
 <iframe class="scormxblock_hostframe" id="scormxblock-{self.url_name}" src="" data-block_id="{self.url_name}"

--- a/scormxblock/static/js/src/scormxblock.js
+++ b/scormxblock/static/js/src/scormxblock.js
@@ -85,9 +85,11 @@ function ScormXBlock_${block_id}(runtime, element) {
     host_frame_${block_id}.data('csrftoken', $.cookie('csrftoken'));
     if (host_frame_${block_id}.data('display_type') == 'iframe') {
       host_frame_${block_id}.css('height', host_frame_${block_id}.data('display_height') + 'px');
+      $('.scorm_launch button').css('display', 'none');
       showScormContent(host_frame_${block_id})
     }
     else if ((host_frame_${block_id}.data('display_type') == 'popup') && (host_frame_${block_id}.data('popup_launch_type') == 'auto')){
+      $('.scorm_launch button').css('display', 'none');
       showScormContent(host_frame_${block_id})
     }
     else{
@@ -100,6 +102,11 @@ function ScormXBlock_${block_id}(runtime, element) {
         launch_btn_${block_id}.removeAttr('disabled');
       })
     }
+
+    document.handleScormPopupClosed = function() {
+      launch_btn = $('.scorm_launch button');
+      launch_btn.removeAttr('disabled');
+    }
   });
 
   function showScormContent(host_frame) {
@@ -109,5 +116,5 @@ function ScormXBlock_${block_id}(runtime, element) {
       playerWin = host_frame[0].contentWindow;
       playerWin.postMessage(host_frame.data(), '*');
     });
-}
+  }
 }

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ def package_data(pkg, roots):
 
 setup(
     name='scormxblock-xblock',
-    version='2.0.20',
+    version='2.0.21',
     description='XBlock to integrate SCORM content packages',
     packages=[
         'scormxblock',


### PR DESCRIPTION
Ticket: https://edx-wiki.atlassian.net/browse/MCKIN-9654
Related PR: https://github.com/edx-solutions/edx-platform/pull/1397

**Description:**
- `% if {show_popup_manually}:` is removed from the html file. Hiding the popup in case of iframe and auto-popup is now handled from scormxblock.js by altering css for e.g. `$('.scorm_launch button').css('display', 'none');`
-  Function `handleScormPopupClosed` is added to the document which is called by the child iframe. The call is coded in the related PR mentioned above.

**Steps to reproduce:**
1. Open a manual popup module page.
2. Launch the manual popup.
3. Observe the launch button is disabled.
4. Close the manual popup.
5. Observe the launch button is enabled.