### PR TITLE
MCKIN-28363 - Exception handling and settings fixes

### DIFF
--- a/scormxblock/scormxblock.py
+++ b/scormxblock/scormxblock.py
@@ -519,7 +519,7 @@ class ScormXBlock(XBlock):
         else:
             return Response('Did not exist in storage: {}'.format(path_to_file).encode('utf-8'), status=404,
                             content_type='text/html', charset='UTF-8')
-        return Response(contents, content_type=content_type)
+        return Response(contents, content_type=str(content_type))
 
     def generate_report_data(self, user_state_iterator, limit_responses=None):
         """

--- a/scormxblock/scormxblock.py
+++ b/scormxblock/scormxblock.py
@@ -36,8 +36,7 @@ def _(text):
 
 logger = logging.getLogger(__name__)
 
-# importing directly from settings.XBLOCK_SETTINGS doesn't work here... doesn't have vals from ENV TOKENS yet
-scorm_settings = settings.ENV_TOKENS['XBLOCK_SETTINGS']['ScormXBlock'] if hasattr(settings, 'ENV_TOKENS') else {}
+scorm_settings = settings.XBLOCK_SETTINGS.get('ScormXBlock', {}) if hasattr(settings, "XBLOCK_SETTINGS") else {}
 DEFINED_PLAYERS = scorm_settings.get("SCORM_PLAYER_BACKENDS", {})
 SCORM_STORAGE = scorm_settings.get("SCORM_PKG_STORAGE_DIR", "scorms")
 SCORM_DISPLAY_STAFF_DEBUG_INFO = scorm_settings.get("SCORM_DISPLAY_STAFF_DEBUG_INFO", False)
@@ -356,9 +355,9 @@ class ScormXBlock(XBlock):
         try:
             state, data = scorm_uploader.upload()
         except Exception as e:
-            logger.error('Scorm package upload error: {}'.format(e.message))
+            logger.error('Scorm package upload error: {}'.format(e))
             ScormPackageUploader.clear_percentage_cache(self.location.block_id)
-            return Response(json.dumps({'status': 'error', 'message': e.message}))
+            return Response(json.dumps({'status': 'error', 'message': str(e)}))
 
         if state == UPLOAD_STATE.PROGRESS:
             response = {"files": [{
@@ -506,18 +505,19 @@ class ScormXBlock(XBlock):
     @XBlock.handler
     def proxy_content(self, request, suffix=''):
         storage = default_storage
-        contents = ''
+        contents = b''
         content_type = 'application/octet-stream'
         path_to_file = os.path.join(SCORM_STORAGE, self.location.block_id, suffix)
 
         if storage.exists(path_to_file):
-            f = storage.open(path_to_file, 'rb')
-            contents = f.read()
+            with storage.open(path_to_file, 'rb') as f:
+                contents = f.read()
+
             ext = os.path.splitext(path_to_file)[1]
             if ext in mimetypes.types_map:
                 content_type = mimetypes.types_map[ext]
         else:
-            return Response('Did not exist in storage: ' + path_to_file, status=404,
+            return Response('Did not exist in storage: {}'.format(path_to_file).encode('utf-8'), status=404,
                             content_type='text/html', charset='UTF-8')
         return Response(contents, content_type=content_type)
 

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ def package_data(pkg, roots):
 
 setup(
     name='scormxblock-xblock',
-    version='3.2.1',
+    version='3.2.2',
     description='XBlock to integrate SCORM content packages',
     packages=[
         'scormxblock',


### PR DESCRIPTION
1. Get scorm settings  from settings.XBLOCK_SETTINGS (this is always loaded in [devstack](https://github.com/edx-solutions/edx-platform/blob/rebase-juniper/lms/envs/devstack.py#L17) & [production](https://github.com/edx-solutions/edx-platform/blob/rebase-juniper/lms/envs/production.py#L747)), otherwise scorm xblock fails loading with following error on devstack: 
```
File "/edx/app/edxapp/venvs/edxapp/lib/python3.5/site-packages/pkg_resources/__init__.py", line 2453, in resolve
edx.devstack-juniper.studio |     module = __import__(self.module_name, fromlist=['__name__'], level=0)
edx.devstack-juniper.studio |   File "/edx/app/edxapp/venvs/edxapp/src/xblock-scorm/scormxblock/__init__.py", line 1, in <module>
edx.devstack-juniper.studio |     from .scormxblock import ScormXBlock
edx.devstack-juniper.studio |   File "/edx/app/edxapp/venvs/edxapp/src/xblock-scorm/scormxblock/scormxblock.py", line 40, in <module>
edx.devstack-juniper.studio |     scorm_settings = settings.ENV_TOKENS['XBLOCK_SETTINGS']['ScormXBlock'] if hasattr(settings, 'ENV_TOKENS') else {}
```
2. Fix exception formatting
3. Close package files after reading
4. `content_type` converted to string as it's reported sometimes as bytes and fails response